### PR TITLE
feat: put kiwigrid/k8s-sidecar on negative list

### DIFF
--- a/images/process/imagecollector/config/imageNegativeList.json
+++ b/images/process/imagecollector/config/imageNegativeList.json
@@ -1,3 +1,4 @@
 [
-  "eu-central-1.amazonaws.com/"
+  "eu-central-1.amazonaws.com/",
+  "kiwigrid/k8s-sidecar"
 ]


### PR DESCRIPTION
put kiwigrid/k8s-sidecar on negative list because it is hard  update without updating the main image