### PR TITLE
More robust handling of image names

### DIFF
--- a/images/process/workflow-runner/module.bash
+++ b/images/process/workflow-runner/module.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 # shellcheck disable=SC2154 # variables come via env, so they are not assigned
-set -ex
+set -e
 
 source ./scan-common.bash
 

--- a/images/process/workflow-runner/module.bash
+++ b/images/process/workflow-runner/module.bash
@@ -39,8 +39,9 @@ while read -r line; do
   appname=$(echo "${DATA_JSON}" | jq -r .app_kubernetes_io_name)
   
   if [ "${appname}" == "" ] || [ "${appname}" == "null" ]; then
-    appname="${IMAGE}"
-    echo "app_kubernetes_io_name is empty, setting to: ${IMAGE}"
+    #IMAGE_NAME is exportet from parse_and_set_image_variables()
+    appname="${IMAGE_NAME}"
+    echo "app_kubernetes_io_name is empty, setting to: ${IMAGE_NAME}"
   fi
   appversion=$(echo "${DATA_JSON}" | jq -r .app_kubernetes_io_version)
   if [ "${appversion}" == "" ] || [ "${appversion}" == "null" ]; then

--- a/images/process/workflow-runner/module.bash
+++ b/images/process/workflow-runner/module.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 # shellcheck disable=SC2154 # variables come via env, so they are not assigned
-set -e
+set -ex
 
 source ./scan-common.bash
 
@@ -33,7 +33,10 @@ while read -r line; do
   IMAGE_ID=$(echo "${DATA_JSON}" | jq -r .image_id)
   export IMAGE_ID #used in parse_and_set_image_variables
   parse_and_set_image_variables
+  
+  
   appname=$(echo "${DATA_JSON}" | jq -r .app_kubernetes_io_name)
+  
   if [ "${appname}" == "" ] || [ "${appname}" == "null" ]; then
     appname="${IMAGE_NAME}"
     echo "app_kubernetes_io_name is empty, setting to: ${IMAGE_NAME}"

--- a/images/process/workflow-runner/module.bash
+++ b/images/process/workflow-runner/module.bash
@@ -43,7 +43,6 @@ while read -r line; do
     appname="${IMAGE_NAME}"
     appname="${appname%@*}"
     appname="${appname%:*}"
-    appname="${appname#*/}"
     echo "app_kubernetes_io_name is empty, setting to: ${appname}"
   fi
   appversion=$(echo "${DATA_JSON}" | jq -r .app_kubernetes_io_version)

--- a/images/process/workflow-runner/module.bash
+++ b/images/process/workflow-runner/module.bash
@@ -29,17 +29,18 @@ while read -r line; do
   namespace=$(echo "${DATA_JSON}" | jq -r .namespace)
   environment=$(echo "${DATA_JSON}" | jq -r .environment)
   team=$(echo "${DATA_JSON}" | jq -r .team)
-  IMAGE_NAME=$(echo "${DATA_JSON}" | jq -r .image)
+  IMAGE=$(echo "${DATA_JSON}" | jq -r .image)
   IMAGE_ID=$(echo "${DATA_JSON}" | jq -r .image_id)
   export IMAGE_ID #used in parse_and_set_image_variables
+  export IMAGE #used in parse_and_set_image_variables
   parse_and_set_image_variables
   
   
   appname=$(echo "${DATA_JSON}" | jq -r .app_kubernetes_io_name)
   
   if [ "${appname}" == "" ] || [ "${appname}" == "null" ]; then
-    appname="${IMAGE_NAME}"
-    echo "app_kubernetes_io_name is empty, setting to: ${IMAGE_NAME}"
+    appname="${IMAGE}"
+    echo "app_kubernetes_io_name is empty, setting to: ${IMAGE}"
   fi
   appversion=$(echo "${DATA_JSON}" | jq -r .app_kubernetes_io_version)
   if [ "${appversion}" == "" ] || [ "${appversion}" == "null" ]; then

--- a/images/process/workflow-runner/module.bash
+++ b/images/process/workflow-runner/module.bash
@@ -41,7 +41,10 @@ while read -r line; do
   if [ "${appname}" == "" ] || [ "${appname}" == "null" ]; then
     #IMAGE_NAME is exportet from parse_and_set_image_variables()
     appname="${IMAGE_NAME}"
-    echo "app_kubernetes_io_name is empty, setting to: ${IMAGE_NAME}"
+    appname="${appname%@*}"
+    appname="${appname%:*}"
+    appname="${appname#*/}"
+    echo "app_kubernetes_io_name is empty, setting to: ${appname}"
   fi
   appversion=$(echo "${DATA_JSON}" | jq -r .app_kubernetes_io_version)
   if [ "${appversion}" == "" ] || [ "${appversion}" == "null" ]; then


### PR DESCRIPTION
When `app_kubernetes_io_name` isn't provided, we fall back on `image` for the application name part of the product string. In some cases that didn't produce usable results. This patch should fix at least some of the issues.