### PR TITLE
remove synchronization

### DIFF
--- a/images/process/workflow-runner/workflow.template.yml
+++ b/images/process/workflow-runner/workflow.template.yml
@@ -6,11 +6,6 @@ metadata:
     clusterscanner.sda.org/scan-id: "###SCAN_ID###"
 spec:
   serviceAccountName: ###SERVICE_ACCOUNT_NAME###
-  synchronization:
-    semaphore:
-      configMapKeyRef:
-        name: synchronization
-        key: workflow
   arguments:
     parameters:
       - name: REGISTRY_SECRET


### PR DESCRIPTION
Due to:
```
NAME                                                              STATUS    AGE   DURATION   PRIORITY   MESSAGE
sj-prd-XXX   Pending   8m    0s         0          Waiting for clusterscanner/ConfigMap/synchronization/workflow lock. Lock status: 16/99
sj-prd-XXX   Pending   8m    0s         0          Waiting for clusterscanner/ConfigMap/synchronization/workflow lock. Lock status: 10/99
sj-prd-XXX  Pending   9m    0s         0          Waiting for clusterscanner/ConfigMap/synchronization/workflow lock. Lock status: 20/99
sj-prd-XXX   Pending   9m    0s         0          Waiting for clusterscanner/ConfigMap/synchronization/workflow lock. Lock status: 8/99
```

We have an additional run limit of pods from the workflow-runner.