### PR TITLE
fix: Do not overload testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -301,7 +301,7 @@ jobs:
           GH_APP_LOGIN: "SDA-SE"
           GH_APP_ID: "143160"
           GH_INSTALLATION_ID: "19959424"
-          GIT_SOURCE_REPOSITORY: "https://api.github.com/repos/SDA-SE/cluster-image-scanner-sda-internal-test-images/tarball"
+          GIT_SOURCE_REPOSITORY: "https://raw.githubusercontent.com/SDA-SE/cluster-scan-test-images/master/test-all.json"
           GIT_COLLECTOR_REPOSITORY: "github.com/SDA-SE/cluster-image-scanner-sda-internal-test-images.git"
         run: |
           pwd


### PR DESCRIPTION
Too many images are fetched via tarball. Therefore, we explicitly select the test image