### PR TITLE
fix(SDDEV-677): Allow sda-product-security to create/modify/delete Argo Workflow resources

### DIFF
--- a/deployment/helm/cluster-image-scanner-orchestrator/templates/roles.yml
+++ b/deployment/helm/cluster-image-scanner-orchestrator/templates/roles.yml
@@ -12,6 +12,30 @@ rules:
   - apiGroups: [""]
     resources: ["*"]
     verbs: ["*"]
+  - apiGroups:
+    - argoproj.io
+    resources:
+    - workflows
+    - workflows/finalizers
+    - workfloweventbindings
+    - workfloweventbindings/finalizers
+    - workflowtemplates
+    - workflowtemplates/finalizers
+    - cronworkflows
+    - cronworkflows/finalizers
+    - clusterworkflowtemplates
+    - clusterworkflowtemplates/finalizers
+    - workflowtaskresults
+    - workflowtaskresults/finalizers
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Allow sda-product-security to create/modify/delete Argo Workflow resources