### PR TITLE
Fix/baseimage vulns

### DIFF
--- a/.github/actions/build_image/action.yml
+++ b/.github/actions/build_image/action.yml
@@ -19,10 +19,38 @@ runs:
     - name: create and push an image
       shell: bash
       run: |
-        source ./test_actions/library.bash
+        # source ./test_actions/library.bash # annoying. The script contains lots of functions, so I directly using the relevant part
+        BRANCH=$(git rev-parse --abbrev-ref HEAD)
+        export BRANCH
+        #export BRANCH="master"
+        export MAJOR="3"
+        export MINOR="0"
+        export PATCH="${GITHUB_RUN_NUMBER}"
+        export VERSION="${MAJOR}.${MINOR}.${PATCH}"
+        if [ "${BRANCH}" != "master" ] && [ "${BRANCH}" != "head" ]; then
+          export MAJOR=$(echo ${BRANCH} | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]//g')
+          export PATCH=""
+          if [ "${GITHUB_RUN_NUMBER}" != "" ]; then
+            echo "Detected GITHUB_RUN_NUMBER"
+            export MINOR="${GITHUB_RUN_NUMBER}"
+            if [ "${GITHUB_HEAD_REF}" != "" ]; then
+              echo "Detected GITHUB_HEAD_REF"
+              export MAJOR=$(echo ${GITHUB_HEAD_REF} | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]//g')
+            fi
+          else
+            export MINOR=""
+          fi
+          export VERSION="${MAJOR}.${MINOR}.${PATCH}"
+        fi
+        VERSION=$(echo ${VERSION} | sed 's#\.$##')
+        VERSION=$(echo ${VERSION} | sed 's#\.$##') # to heal two .
+        echo "VERSION: ${VERSION}"
+
         cd ${{ inputs.image-path }}
         
         find . -type f -name "*.bash" -print0 | xargs -0 sed -i "s#quay.io/sdase/cluster-image-scanner-base:2#quay.io/sdase/cluster-image-scanner-base:${VERSION}#g"
         find . -type f -name "*.sh" -print0 | xargs -0 sed -i "s#quay.io/sdase/cluster-image-scanner-base:2#quay.io/sdase/cluster-image-scanner-base:${VERSION}#g"
+        find . -type f -name "*.bash" -print0 | xargs -0 sed -i "s#quay.io/sdase/cluster-image-scanner-base:3#quay.io/sdase/cluster-image-scanner-base:${VERSION}#g"
+        find . -type f -name "*.sh" -print0 | xargs -0 sed -i "s#quay.io/sdase/cluster-image-scanner-base:3#quay.io/sdase/cluster-image-scanner-base:${VERSION}#g"
         chmod +x ./build.sh
         sudo ./build.sh "quay.io" "sdase" "${{ inputs.image-name }}" "${VERSION}" "${{ inputs.registry-user }}" "${{ inputs.registry-token }}" true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       (github.event_name == 'push') ||
       (github.event_name == 'workflow_dispatch')
     steps:
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+      - uses: actions/checkout@v4 # before: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
       - uses: ./.github/actions/build_image
         with:
           image-path: images/base

--- a/images/base/build.sh
+++ b/images/base/build.sh
@@ -33,11 +33,11 @@ dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 build_dir="${dir}/build"
 
 
-skopeo_image="registry.access.redhat.com/ubi8/go-toolset:latest"
+skopeo_image="registry.access.redhat.com/ubi9/go-toolset:latest"
 ctr_skopeo="$( buildah from --pull --quiet "${skopeo_image}")"
 mnt_skopeo="$( buildah mount "${ctr_skopeo}")"
 
-base_image="registry.access.redhat.com/ubi8-init" # minimal doesn't have useradd
+base_image="registry.access.redhat.com/ubi9-init" # minimal doesn't have useradd
 ctr_tools="$( buildah from --pull --quiet "${base_image}")"
 mnt_tools="$( buildah mount "${ctr_tools}")"
 

--- a/tests/scan-common.bats
+++ b/tests/scan-common.bats
@@ -98,7 +98,7 @@ empty_template=$(get_template)
 }
 
 @test "add_json_field() should return 1 when a non-existing field is targeted" {
-    run -1 add_json_field non_existing_field "test" "$(<tmp/clean_simple.json)"
+    run -1 add_json_field non_existing_field "test" "$clean_simple_json"
 }
 
 @test "add_json_field() should return 1 when called with less than 3 or more than 4 parameters" {


### PR DESCRIPTION
Fixing [quay.io/repository/sdase/cluster-image-scanner-base:3](https://quay.io/repository/sdase/cluster-image-scanner-base/manifest/sha256:199ec1da4dd115fb9d48bcbea52c28df33b044197fc8b89557875c58c1c7097b?tab=vulnerabilities&fixable=true)


  | Advisory | Severity | Package | Current version | Fixed in version | Introduced in layer |  
-- | -- | -- | -- | -- | -- | -- | --
  | GHSA-v778-237x-gjrc | Critical | golang.org/x/crypto | v0.26.0 | 0.31.0 | /bin/sh |  
  | GO-2024-3171 | High | github.com/containers/common | v0.60.2 | 0.60.4 | /bin/sh |  
  | GHSA-w32m-9786-jp63 | High | golang.org/x/net | v0.28.0 | 0.33.0 | /bin/sh |  
  | GHSA-mc76-5925-c5p6 | Medium | github.com/containers/common | v0.60.2 | 0.60.4 | /bin/sh |  
  | GO-2024-3333 | Unknown | golang.org/x/net | v0.28.0 | 0.33.0 | /bin/sh |  
  | GO-2024-3321 | Unknown | golang.org/x/crypto | v0.26.0 | 0.31.0 | /bin/sh

