### PR TITLE
Feature/monitoring

### DIFF
--- a/deployment/helm/cluster-image-scanner-orchestrator-base/templates/orchestration-job.yml
+++ b/deployment/helm/cluster-image-scanner-orchestrator-base/templates/orchestration-job.yml
@@ -76,6 +76,19 @@ spec:
             template: cleanup-dependency-track
 
     - name: fetch-image-list
+      metrics:
+        prometheus:
+          - name: fetch_image_list_status
+            labels:
+              - key: workflow_name
+                value: "{{workflow.name}}"
+              - key: workflow_namespace
+                value: "{{workflow.namespace}}"
+              - key: status
+                value: "{{status}}"
+            help: "Count of executions in the fetch-image-list"
+            counter:
+              value: "1"
       outputs:
         artifacts:
           - name: image-lists
@@ -177,6 +190,19 @@ spec:
             value: "true" # TODO false
 
     - name: notify-teams
+      metrics:
+        prometheus:
+          - name: notify_teams_status
+            labels:
+              - key: workflow_name
+                value: "{{workflow.name}}"
+              - key: workflow_namespace
+                value: "{{workflow.namespace}}"
+              - key: status
+                value: "{{status}}"
+            help: "Count of executions in the notify-teams"
+            counter:
+              value: "1"
       volumes:
         - name: scandata
           persistentVolumeClaim:
@@ -481,6 +507,19 @@ spec:
           echo "${errors}"
 
     - name: generate-lifetime-statistics
+      metrics:
+        prometheus:
+          - name: generate_lifetime_statistics_status
+            labels:
+              - key: workflow_name
+                value: "{{workflow.name}}"
+              - key: workflow_namespace
+                value: "{{workflow.namespace}}"
+              - key: status
+                value: "{{status}}"
+            help: "Count of executions in the generate-lifetime-statistics"
+            counter:
+              value: "1"
       volumes:
         - name: scandata
           persistentVolumeClaim:
@@ -631,6 +670,19 @@ spec:
 
 
     - name: generate-response-statistics
+      metrics:
+        prometheus:
+          - name: generate_response_statistics_status
+            labels:
+              - key: workflow_name
+                value: "{{workflow.name}}"
+              - key: workflow_namespace
+                value: "{{workflow.namespace}}"
+              - key: status
+                value: "{{status}}"
+            help: "Count of executions in the generate-response-statistics"
+            counter:
+              value: "1"
       outputs:
         artifacts:
           - name: team-statistics
@@ -658,6 +710,19 @@ spec:
               name: "{{ "{{" }} workflow.parameters.defectDojoConfigMapName {{ "}}" }}"
 
     - name: git-upload-response-statistics
+      metrics:
+        prometheus:
+          - name: git_upload_response_statistics_status
+            labels:
+              - key: workflow_name
+                value: "{{workflow.name}}"
+              - key: workflow_namespace
+                value: "{{workflow.namespace}}"
+              - key: status
+                value: "{{status}}"
+            help: "Count of executions in the git-upload-response-statistics"
+            counter:
+              value: "1"
       volumes:
         - name: "{{ "{{" }} workflow.parameters.gitSecretName {{ "}}" }}"
           secret:
@@ -730,6 +795,19 @@ spec:
 
 
     - name: cleanup-dependency-track
+      metrics:
+        prometheus:
+          - name: cleanup_dt_status
+            labels:
+              - key: workflow_name
+                value: "{{workflow.name}}"
+              - key: workflow_namespace
+                value: "{{workflow.namespace}}"
+              - key: status
+                value: "{{status}}"
+            help: "Count of executions in the cleanup-dependency-track"
+            counter:
+              value: "1"
       volumes:
         - name: tmp
           emptyDir: { }

--- a/deployment/helm/cluster-image-scanner-orchestrator-base/templates/orchestration-job.yml
+++ b/deployment/helm/cluster-image-scanner-orchestrator-base/templates/orchestration-job.yml
@@ -4,6 +4,23 @@ metadata:
   name: orchestration-job-template
   namespace: {{ .Release.Namespace }}
 spec:
+  metrics:
+    prometheus:
+    - name: workflow_failed_steps
+      gauge:
+        value: "{{ workflow.failures }}"
+      help: "Count of failed steps in workflow"
+      labels:
+      - key: workflow_name
+        value: "{{ workflow.name }}"
+      - key: workflow_namespace
+        value: "{{ workflow.namespace }}"
+      - key: workflow_template
+        value: "{{ workflow.labels['workflows.argoproj.io/workflow-template'] }}"
+    - name: workflow_duration_seconds
+      gauge:
+        value: "{{ workflow.duration }}"
+      help: "Workflow execution duration in seconds"
   onExit: exit-handler
   activeDeadlineSeconds: {{ .Values.orchestrationJob.activeDeadlineSeconds }}
   entrypoint: main # Entry point for job execution

--- a/deployment/helm/cluster-image-scanner-orchestrator-base/templates/orchestration-job.yml
+++ b/deployment/helm/cluster-image-scanner-orchestrator-base/templates/orchestration-job.yml
@@ -15,8 +15,6 @@ spec:
         value: "{{ workflow.name }}"
       - key: workflow_namespace
         value: "{{ workflow.namespace }}"
-      - key: workflow_template
-        value: "{{ workflow.labels['workflows.argoproj.io/workflow-template'] }}"
     - name: workflow_duration_seconds
       gauge:
         value: "{{ workflow.duration }}"

--- a/deployment/helm/cluster-image-scanner-orchestrator-base/templates/scanjob.yml
+++ b/deployment/helm/cluster-image-scanner-orchestrator-base/templates/scanjob.yml
@@ -149,6 +149,19 @@ spec:
                   optional: true
 
     - name: imagefetcher
+      metrics:
+        prometheus:
+          - name: imagefetcher_status
+            labels:
+              - key: workflow_name
+                value: "{{workflow.name}}"
+              - key: workflow_namespace
+                value: "{{workflow.namespace}}"
+              - key: status
+                value: "{{ status }}"
+            help: "Count of executions of the imagefetcher and status"
+            counter:
+              value: "1"
       volumes:
         - name: images
           persistentVolumeClaim:
@@ -382,6 +395,19 @@ spec:
 
 
     - name: sbom-generation
+      metrics:
+        prometheus:
+          - name: sbom-generation_status
+            labels:
+              - key: workflow_name
+                value: "{{workflow.name}}"
+              - key: workflow_namespace
+                value: "{{workflow.namespace}}"
+              - key: status
+                value: "{{ status }}"
+            help: "Count of executions of the sbom-generation and status"
+            counter:
+              value: "1"
       volumes:
         - name: images
           persistentVolumeClaim:
@@ -426,6 +452,19 @@ spec:
             subPath: "results/{{ "{{" }} workflow.parameters.image_id {{ "}}" }}/sbom"
 
     - name: dtrack
+      metrics:
+        prometheus:
+          - name: dtrack_status
+            labels:
+              - key: workflow_name
+                value: "{{workflow.name}}"
+              - key: workflow_namespace
+                value: "{{workflow.namespace}}"
+              - key: status
+                value: "{{ status }}"
+            help: "Count of executions of the dtrack and status"
+            counter:
+              value: "1"
       volumes:
         - name: scandata
           persistentVolumeClaim:
@@ -606,6 +645,19 @@ spec:
           fi
 
     - name: dtrack-notify-thresholds
+      metrics:
+        prometheus:
+          - name: dtrack-notify-thresholds_status
+            labels:
+              - key: workflow_name
+                value: "{{workflow.name}}"
+              - key: workflow_namespace
+                value: "{{workflow.namespace}}"
+              - key: status
+                value: "{{ status }}"
+            help: "Count of executions of the dtrack-notify-thresholds and status"
+            counter:
+              value: "1"
       volumes:
         - name: tmp
           emptyDir: { }
@@ -665,6 +717,19 @@ spec:
           echo "${CONTENT}"
 
     - name: dtrack-dd-upload
+      metrics:
+        prometheus:
+          - name: dtrack-dd-upload_status
+            labels:
+              - key: workflow_name
+                value: "{{workflow.name}}"
+              - key: workflow_namespace
+                value: "{{workflow.namespace}}"
+              - key: status
+                value: "{{ status }}"
+            help: "Count of executions of the dtrack-dd-upload and status"
+            counter:
+              value: "1"
       volumes:
         - name: scandata
           persistentVolumeClaim:
@@ -732,6 +797,19 @@ spec:
             value: "{{ "{{" }} inputs.parameters.dependency-track-notification-alerts{{ "}}" }}"
 
     - name: distroless
+      metrics:
+        prometheus:
+          - name: distroless_status
+            labels:
+              - key: workflow_name
+                value: "{{workflow.name}}"
+              - key: workflow_namespace
+                value: "{{workflow.namespace}}"
+              - key: status
+                value: "{{ status }}"
+            help: "Count of executions of the distroless and status"
+            counter:
+              value: "1"
       volumes:
         - name: images
           persistentVolumeClaim:
@@ -770,6 +848,19 @@ spec:
               name: "{{ "{{" }} workflow.parameters.scanjobEnvParameter{{ "}}" }}"
 
     - name: lifetime
+      metrics:
+        prometheus:
+          - name: lifetime_status
+            labels:
+              - key: workflow_name
+                value: "{{workflow.name}}"
+              - key: workflow_namespace
+                value: "{{workflow.namespace}}"
+              - key: status
+                value: "{{ status }}"
+            help: "Count of executions of the lifetime and status"
+            counter:
+              value: "1"
       volumes:
         - name: scandata
           persistentVolumeClaim:
@@ -809,6 +900,19 @@ spec:
               name: "{{ "{{" }} workflow.parameters.scanjobEnvParameter{{ "}}" }}"
 
     - name: base-lifetime
+      metrics:
+        prometheus:
+          - name: base-lifetime_status
+            labels:
+              - key: workflow_name
+                value: "{{workflow.name}}"
+              - key: workflow_namespace
+                value: "{{workflow.namespace}}"
+              - key: status
+                value: "{{ status }}"
+            help: "Count of executions of the base-lifetime and status"
+            counter:
+              value: "1"
       volumes:
         - name: scandata
           persistentVolumeClaim:
@@ -863,6 +967,19 @@ spec:
               name: "{{ "{{" }} workflow.parameters.scanjobEnvParameter{{ "}}" }}"
 
     - name: runasroot
+      metrics:
+        prometheus:
+          - name: runasroot_status
+            labels:
+              - key: workflow_name
+                value: "{{workflow.name}}"
+              - key: workflow_namespace
+                value: "{{workflow.namespace}}"
+              - key: status
+                value: "{{ status }}"
+            help: "Count of executions of the runasroot and status"
+            counter:
+              value: "1"
       volumes:
         - name: registry-creds
           secret:
@@ -900,6 +1017,19 @@ spec:
               name: "{{ "{{" }} workflow.parameters.scanjobEnvParameter{{ "}}" }}"
 
     - name: new-version
+      metrics:
+        prometheus:
+          - name: new-version_status
+            labels:
+              - key: workflow_name
+                value: "{{workflow.name}}"
+              - key: workflow_namespace
+                value: "{{workflow.namespace}}"
+              - key: status
+                value: "{{ status }}"
+            help: "Count of executions of the new-version and status"
+            counter:
+              value: "1"
       volumes:
         - name: registry-creds
           secret:
@@ -941,6 +1071,19 @@ spec:
               name: "{{ "{{" }} workflow.parameters.scanjobEnvParameter{{ "}}" }}"
 
     - name: malware
+      metrics:
+        prometheus:
+          - name: malware_status
+            labels:
+              - key: workflow_name
+                value: "{{workflow.name}}"
+              - key: workflow_namespace
+                value: "{{workflow.namespace}}"
+              - key: status
+                value: "{{ status }}"
+            help: "Count of executions of the malware and status"
+            counter:
+              value: "1"
       volumes:
         - name: images
           persistentVolumeClaim:
@@ -988,6 +1131,19 @@ spec:
               name: "{{ "{{" }} workflow.parameters.scanjobEnvParameter{{ "}}" }}"
 
     - name: col-gen-finds
+      metrics:
+        prometheus:
+          - name: col-gen-finds_status
+            labels:
+              - key: workflow_name
+                value: "{{workflow.name}}"
+              - key: workflow_namespace
+                value: "{{workflow.namespace}}"
+              - key: status
+                value: "{{ status }}"
+            help: "Count of executions of the col-gen-finds and status"
+            counter:
+              value: "1"
       volumes:
         - name: scandata
           persistentVolumeClaim:
@@ -1125,6 +1281,19 @@ spec:
 
 
     - name: gen-dd-upload
+      metrics:
+        prometheus:
+          - name: gen-dd-upload_status
+            labels:
+              - key: workflow_name
+                value: "{{workflow.name}}"
+              - key: workflow_namespace
+                value: "{{workflow.namespace}}"
+              - key: status
+                value: "{{ status }}"
+            help: "Count of executions of the gen-dd-upload and status"
+            counter:
+              value: "1"
       inputs:
         artifacts:
           - name: results-generic-findings
@@ -1184,6 +1353,19 @@ spec:
             mountPath: /tmp
 
     - name: aggregate
+      metrics:
+        prometheus:
+          - name: aggregate_status
+            labels:
+              - key: workflow_name
+                value: "{{workflow.name}}"
+              - key: workflow_namespace
+                value: "{{workflow.namespace}}"
+              - key: status
+                value: "{{ status }}"
+            help: "Count of executions of the aggregate and status"
+            counter:
+              value: "1"
       inputs:
         artifacts:
           - name: results-dd-generic-test-link

--- a/deployment/helm/cluster-image-scanner-orchestrator-base/templates/scanjob.yml
+++ b/deployment/helm/cluster-image-scanner-orchestrator-base/templates/scanjob.yml
@@ -4,6 +4,23 @@ metadata:
   name: scan-image-job-template
   namespace: {{ .Release.Namespace }}
 spec:
+  metrics:
+    prometheus:
+    - name: workflow_failed_steps
+      gauge:
+        value: "{{ workflow.failures }}"
+      help: "Count of failed steps in workflow"
+      labels:
+      - key: workflow_name
+        value: "{{ workflow.name }}"
+      - key: workflow_namespace
+        value: "{{ workflow.namespace }}"
+      - key: workflow_template
+        value: "{{ workflow.labels['workflows.argoproj.io/workflow-template'] }}"
+    - name: workflow_duration_seconds
+      gauge:
+        value: "{{ workflow.duration }}"
+      help: "Workflow execution duration in seconds"
   onExit: exit-handler
   activeDeadlineSeconds: {{ .Values.scanjob.activeDeadlineSeconds }}
   artifactRepositoryRef:

--- a/deployment/helm/cluster-image-scanner-orchestrator-base/templates/scanjob.yml
+++ b/deployment/helm/cluster-image-scanner-orchestrator-base/templates/scanjob.yml
@@ -15,8 +15,6 @@ spec:
         value: "{{ workflow.name }}"
       - key: workflow_namespace
         value: "{{ workflow.namespace }}"
-      - key: workflow_template
-        value: "{{ workflow.labels['workflows.argoproj.io/workflow-template'] }}"
     - name: workflow_duration_seconds
       gauge:
         value: "{{ workflow.duration }}"

--- a/deployment/helm/cluster-image-scanner-orchestrator-base/templates/servicemonitor.yaml
+++ b/deployment/helm/cluster-image-scanner-orchestrator-base/templates/servicemonitor.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceMonitor.deploy }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -18,3 +19,4 @@ spec:
       path: /metrics
       interval: {{ .Values.serviceMonitor.interval | default "30s" }}
   jobLabel: workflow-metrics
+{{- end }}

--- a/deployment/helm/cluster-image-scanner-orchestrator-base/templates/servicemonitor.yaml
+++ b/deployment/helm/cluster-image-scanner-orchestrator-base/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceMonitor.deploy }}
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/deployment/helm/cluster-image-scanner-orchestrator-base/templates/servicemonitor.yaml
+++ b/deployment/helm/cluster-image-scanner-orchestrator-base/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-workflow-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    release: prometheus-operator
+spec:
+  namespaceSelector:
+    matchNames:
+      - argowf  # namespace where Argo Workflow controller is installed
+  selector:
+    matchLabels:
+      app: argo-argo-workflows-workflow-controller  # matches the Argo Workflow controller service
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.serviceMonitor.interval | default "30s" }}
+  jobLabel: workflow-metrics

--- a/deployment/helm/cluster-image-scanner-orchestrator-base/values.yaml
+++ b/deployment/helm/cluster-image-scanner-orchestrator-base/values.yaml
@@ -345,5 +345,6 @@ smtp:
   smtpEnforceMailTo: ""
 
 serviceMonitor:
+  deploy: false
   enabled: true
   interval: "30s"

--- a/deployment/helm/cluster-image-scanner-orchestrator-base/values.yaml
+++ b/deployment/helm/cluster-image-scanner-orchestrator-base/values.yaml
@@ -345,6 +345,5 @@ smtp:
   smtpEnforceMailTo: ""
 
 serviceMonitor:
-  deploy: false
-  enabled: true
+  enabled: false
   interval: "30s"

--- a/deployment/helm/cluster-image-scanner-orchestrator-base/values.yaml
+++ b/deployment/helm/cluster-image-scanner-orchestrator-base/values.yaml
@@ -344,3 +344,6 @@ smtp:
   smtpMailParameter: ""
   smtpEnforceMailTo: ""
 
+serviceMonitor:
+  enabled: true
+  interval: "30s"


### PR DESCRIPTION
This PR extends the cluster-image-scanner orchestrator Helm chart by enabling Prometheus metrics for Argo Workflows. The changes add custom metrics to both the orchestration-job and scanjob templates, allowing us to track the number of failed workflow steps and the overall duration of each workflow execution. Additionally, an optional ServiceMonitor is introduced to scrape these metrics from the Argo Workflows controller (can be enabled if not running already in the argowf namespace).