### PR TITLE
chore(catalog): migrate deprecated metadata

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,14 +2,12 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: ClusterImageScanner
+  title: Cluster Image Scanner
   description: |
     Discover vulnerabilities and container image misconfiguration in production environments.
   tags:
     - security-stack
   annotations:
-    sda.se/summary: |
-      Discover vulnerabilities and container image misconfiguration in production environments.
-    sda.se/federation-scopes: public
     backstage.io/techdocs-ref: url:https://github.com/SDA-SE/cluster-image-scanner/tree/master
   links:
     - url: https://github.com/SDA-SE/cluster-image-scanner/


### PR DESCRIPTION
## Catalog metadata migration

### Removed annotations

- `sda.se/federation-scopes`
- `sda.se/summary`

### Added titles

- `Component:default/ClusterImageScanner` → **Cluster Image Scanner**

### Description decisions

- Existing verified descriptions retained.

### Template changes

- None.

### Validation

- `catalog_guard.py --json`: pass; 0 errors/findings.
- `git diff --check`: pass.

### Manual review

- No unresolved metadata decisions. Peer review required before merge.
